### PR TITLE
feat(response): add assertSee

### DIFF
--- a/src/Response/index.js
+++ b/src/Response/index.js
@@ -113,13 +113,13 @@ module.exports = function (Config) {
     /**
      * Asserts the response contains something
      *
-     * @method assertTSee
+     * @method assertTextHas
      *
      * @param  {String}   expected
      *
      * @return {void}
      */
-    assertSee (expected) {
+    assertTextHas (expected) {
       this._assert.include(this.text, expected)
       return this
     }

--- a/src/Response/index.js
+++ b/src/Response/index.js
@@ -111,6 +111,20 @@ module.exports = function (Config) {
     }
 
     /**
+     * Asserts the response contains something
+     *
+     * @method assertTSee
+     *
+     * @param  {String}   expected
+     *
+     * @return {void}
+     */
+    assertSee (expected) {
+      this._assert.include(this.text, expected)
+      return this
+    }
+
+    /**
      * Asserts the response text
      *
      * @method assertText


### PR DESCRIPTION
Hey 👋 

This method can be useful when you don't want to run the browser but still want to assert that the response contains something.

**Example:**
```js
test('a user can browse threads', async ({ assert, client }) => {
  const thread = await Factory.model('App/Models/Thread').create(1)
  const response = await client.get('/threads').end()

  response.assertStatus(200)
  response.assertSee(thread.title)
})
```