### PR TITLE
Add silent option to migrations in vowfile

### DIFF
--- a/templates/vowfile.js
+++ b/templates/vowfile.js
@@ -34,7 +34,7 @@ module.exports = (cli, runner) => {
     | Migrate the database before starting the tests.
     |
     */
-    // await ace.call('migration:run')
+    // await ace.call('migration:run', {}, { silent: true })
   })
 
   runner.after(async () => {
@@ -57,6 +57,6 @@ module.exports = (cli, runner) => {
     | original state
     |
     */
-    // await ace.call('migration:reset')
+    // await ace.call('migration:reset', {}, { silent: true })
   })
 }


### PR DESCRIPTION
## Proposed changes

By default the migration output is shown, with silent option only one message with the migration status is shown.

## Types of changes

Migrations are now runned in silent mode.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-vow/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)