### PR TITLE
added ability to select reports dynamically

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "chai-subset": "^1.6.0",
     "debug": "^3.1.0",
     "globby": "^8.0.1",
-    "japa": "link:.yalc/japa",
+    "japa": "^1.0.6",
     "lodash": "^4.17.10",
     "macroable": "^1.0.0",
     "node-cookie": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "chai-subset": "^1.6.0",
     "debug": "^3.1.0",
     "globby": "^8.0.1",
-    "japa": "^1.0.6",
+    "japa": "link:.yalc/japa",
     "lodash": "^4.17.10",
     "macroable": "^1.0.0",
     "node-cookie": "^2.1.0",

--- a/src/Runner/index.js
+++ b/src/Runner/index.js
@@ -10,6 +10,7 @@
 */
 
 const { Runner, reporters, Assertion } = require('japa/api')
+const { InvalidArgumentException } = require('@adonisjs/generic-exceptions')
 const pSeries = require('p-series')
 const { resolver } = require('@adonisjs/fold')
 const debug = require('debug')('adonis:vow:runner')
@@ -88,6 +89,9 @@ class TestRunner {
    * @private
    */
   reporter (reporterFn) {
+    if (typeof (reporterFn) !== 'function') {
+      throw new InvalidArgumentException('Reporter must be a function that accepts an emitter')
+    }
     this._reporter = reporterFn
   }
 

--- a/src/Runner/index.js
+++ b/src/Runner/index.js
@@ -10,7 +10,6 @@
 */
 
 const { Runner, reporters, Assertion } = require('japa/api')
-const { InvalidArgumentException } = require('@adonisjs/generic-exceptions')
 const pSeries = require('p-series')
 const { resolver } = require('@adonisjs/fold')
 const debug = require('debug')('adonis:vow:runner')
@@ -89,9 +88,6 @@ class TestRunner {
    * @private
    */
   reporter (reporterFn) {
-    if (typeof (reporterFn) !== 'function') {
-      throw new InvalidArgumentException('Reporter must be a function that accepts an emitter')
-    }
     this._reporter = reporterFn
   }
 

--- a/src/Runner/index.js
+++ b/src/Runner/index.js
@@ -28,7 +28,7 @@ Assertion.use(require('chai-subset'))
 class TestRunner {
   constructor (Env) {
     this.clear()
-    this._reporter = Env.get('REPORTER', reporters.list)
+    this._reporter = reporters[Env.get('REPORTER', 'list')]
   }
 
   /**

--- a/src/Runner/index.js
+++ b/src/Runner/index.js
@@ -81,6 +81,17 @@ class TestRunner {
   }
 
   /**
+   * Set the reporter function to a custom one
+   *
+   * @method reporter
+   *
+   * @private
+   */
+  reporter (reporterFn) {
+    this._reporter = reporterFn
+  }
+
+  /**
    * Clear properties of runner.
    *
    * @method clear

--- a/test/unit/runner.spec.js
+++ b/test/unit/runner.spec.js
@@ -11,6 +11,7 @@
 
 const test = require('japa')
 const { setupResolver, Env, Config } = require('@adonisjs/sink')
+const { InvalidArgumentException } = require('@adonisjs/generic-exceptions')
 const { ioc } = require('@adonisjs/fold')
 const Runner = require('../../src/Runner')
 const props = require('../../lib/props')
@@ -307,4 +308,12 @@ test.group('Runner', (group) => {
     await this.runner.run()
     assert.deepEqual(called, ['group_start', 'test_start', 'run_test', 'test_end', 'group_end'])
   })
+})
+
+test('run runner reporter must be a function', async (assert) => {
+  try {
+    this.runner.reporter('Not a function')
+  } catch (error) {
+    assert.instanceOf(error, InvalidArgumentException)
+  }
 })

--- a/test/unit/runner.spec.js
+++ b/test/unit/runner.spec.js
@@ -11,7 +11,6 @@
 
 const test = require('japa')
 const { setupResolver, Env, Config } = require('@adonisjs/sink')
-const { InvalidArgumentException } = require('@adonisjs/generic-exceptions')
 const { ioc } = require('@adonisjs/fold')
 const Runner = require('../../src/Runner')
 const props = require('../../lib/props')
@@ -308,12 +307,4 @@ test.group('Runner', (group) => {
     await this.runner.run()
     assert.deepEqual(called, ['group_start', 'test_start', 'run_test', 'test_end', 'group_end'])
   })
-})
-
-test('run runner reporter must be a function', async (assert) => {
-  try {
-    this.runner.reporter('Not a function')
-  } catch (error) {
-    assert.instanceOf(error, InvalidArgumentException)
-  }
 })

--- a/test/unit/runner.spec.js
+++ b/test/unit/runner.spec.js
@@ -283,7 +283,7 @@ test.group('Runner', (group) => {
     const suite = this.runner.suite('sample')
 
     suite.test('test', function () {
-      called.push("run_test")
+      called.push('run_test')
     })
 
     this.runner.reporter(function (emitter) {

--- a/test/unit/runner.spec.js
+++ b/test/unit/runner.spec.js
@@ -277,4 +277,34 @@ test.group('Runner', (group) => {
     const emitter = new EventEmitter()
     this.runner.emitter(emitter)
   })
+
+  test('run runner set custom reporter', async (assert) => {
+    const called = []
+    const suite = this.runner.suite('sample')
+
+    suite.test('test', function () {
+      called.push("run_test")
+    })
+
+    this.runner.reporter(function (emitter) {
+      emitter.on('group:start', () => {
+        called.push('group_start')
+      })
+
+      emitter.on('group:end', () => {
+        called.push('group_end')
+      })
+
+      emitter.on('test:start', () => {
+        called.push('test_start')
+      })
+
+      emitter.on('test:end', () => {
+        called.push('test_end')
+      })
+    })
+
+    await this.runner.run()
+    assert.deepEqual(called, ['group_start', 'test_start', 'run_test', 'test_end', 'group_end'])
+  })
 })


### PR DESCRIPTION
## Proposed changes

Fixes #29 this small changes allow you to select a different reporter by prepending REPORTER ='<name of reporter>' to adonis test I am working on a json reporter for japa at the moment which I will submit soon

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-vow/CONTRIBUTING.md) doc
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have added necessary documentation (if appropriate)
