### PR TITLE
fix: Fix the order of the files when running the tests

### DIFF
--- a/commands/RunTests.js
+++ b/commands/RunTests.js
@@ -156,7 +156,7 @@ class RunTests extends Command {
     /**
      * Getting all test files from the cli
      */
-    let testFiles = await this.cli.getTestFiles()
+    let testFiles = (await this.cli.getTestFiles()).sort()
 
     /**
      * If there are specific files defined, then grep on


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

Fix order of files when running test, now tests will run according to the order of
files in directory.

See more [in this question](https://forum.adonisjs.com/t/sequential-testing/3476/8)

## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-vow/blob/develop/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)
