### PR TITLE
feat(runner): return japa Hook instance

### DIFF
--- a/src/Suite/index.js
+++ b/src/Suite/index.js
@@ -176,10 +176,10 @@ class Suite {
    *
    * @param  {Function} callback
    *
-   * @return {void}
+   * @return {Object} Instance of japa hook
    */
   beforeEach (callback) {
-    this.group.beforeEach(callback)
+    return this.group.beforeEach(callback)
   }
 
   /**
@@ -190,10 +190,10 @@ class Suite {
    *
    * @param  {Function} callback
    *
-   * @return {void}
+   * @return {Object} Instance of japa hook
    */
   afterEach (callback) {
-    this.group.afterEach(callback)
+    return this.group.afterEach(callback)
   }
 
   /**
@@ -204,10 +204,10 @@ class Suite {
    *
    * @param  {Function} callback
    *
-   * @return {void}
+   * @return {Object} Instance of japa hook
    */
   after (callback) {
-    this.group.after(callback)
+    return this.group.after(callback)
   }
 
   /**
@@ -218,10 +218,10 @@ class Suite {
    *
    * @param  {Function} callback
    *
-   * @return {void}
+   * @return {Object} Instance of japa hook
    */
   before (callback) {
-    this.group.before(callback)
+    return this.group.before(callback)
   }
 
   /**

--- a/test/integration/runner.spec.js
+++ b/test/integration/runner.spec.js
@@ -57,11 +57,11 @@ jTest.group('Runner', (group) => {
 
     beforeEach(() => {
       called.push('beforeEach')
-    })
+    }).timeout(2000) // Timeout function should be callable from here
 
     afterEach(() => {
       called.push('afterEach')
-    })
+    }).timeout(2000) // Timeout function should be callable from here
 
     const runner = use('Test/Runner')
     test('2 + 2 is 4', function ({ assert }) {


### PR DESCRIPTION
## Proposed changes

I was desperately trying to specify a timeout to my Suite hooks, without having to change the Suite &/or global timeout. It is a japa feature that was not reachable because of the vow implementation not returning the hook (returned by japa on hook declaration).

This PR aims to fix this bug, &/or to add the japa feature to vow.

## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-vow/blob/develop/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)

## Example code & before/after
Example code:
```javascript
const { test, trait, before, after } = use('Test/Suite')('my_test')

before(async () => {

  await longInitOperation()

}).timeout(10000)
```
Without calling timeout:
```
  1. my_test
  Error: Hook timeout, ensure "done()" is called; if returning a Promise, ensure it resolves.
    at Hook._parseError (/home/.../node_modules/japa/src/Hook.js:42:16)
```

With calling timeout, before:
```
error: message=Cannot read property 'timeout' of undefined, stack=TypeError: Cannot read property 'timeout' of undefined
    at Object.<anonymous> (/home/.../my_test.spec.js:85:1)
```
With calling timeout, after : the test runs successfully :)
```
   PASSED 

  total       : 6
  passed      : 6
  time        : 8s
```