### PR TITLE
Add "trait" method to runner instance for global traits

### DIFF
--- a/templates/vowfile.js
+++ b/templates/vowfile.js
@@ -37,6 +37,16 @@ module.exports = (cli, runner) => {
     // await ace.call('migration:run', {}, { silent: true })
   })
 
+  /*
+    |--------------------------------------------------------------------------
+    | Run migrations
+    |--------------------------------------------------------------------------
+    |
+    | Reset the database after each test
+    |
+  */
+  // runner.trait('DatabaseTransactions')
+
   runner.after(async () => {
     /*
     |--------------------------------------------------------------------------

--- a/test/unit/runner.spec.js
+++ b/test/unit/runner.spec.js
@@ -136,6 +136,17 @@ test.group('Runner', (group) => {
     assert.deepEqual(called, ['trait 1', 'trait 2'])
   })
 
+  test('run global traits before running any tests', async (assert) => {
+    const suite = this.runner.suite('sample')
+    const called = []
+
+    this.runner.trait(() => called.push('trait 1'))
+    suite.trait(() => called.push('trait 2'))
+
+    await this.runner.run()
+    assert.deepEqual(called, ['trait 1', 'trait 2'])
+  })
+
   test('attach values to suite when running suite traits', async (assert) => {
     const suite = this.runner.suite('sample')
     const called = []


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

Currently, to use the "DatabaseTransactions" trait you need to add it to each test. But chances are, if you use it in one test, you likely need it in all the other ones that require db access too. This change allows you to add traits to the runner instance, these "global traits" will be added to each test suite.
Now the migration process for testing is all inside "vowfile.js".

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-vow/blob/develop/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)