### PR TITLE
Filter test files using "includes" instead of "equals"

### DIFF
--- a/commands/RunTests.js
+++ b/commands/RunTests.js
@@ -156,20 +156,7 @@ class RunTests extends Command {
     /**
      * Getting all test files from the cli
      */
-    let testFiles = await this.cli.getTestFiles()
-
-    /**
-     * If there are specific files defined, then grep on
-     * them to pick only those files
-     */
-    if (_.size(filesToPick)) {
-      testFiles = _.filter(testFiles, (file) => {
-        return _.some(filesToPick, (selectedFile) => {
-          return file.includes(selectedFile.trim())
-        })
-      })
-      debug('post --files filter %j', testFiles)
-    }
+    const testFiles = await this.cli.getTestFiles(filesToPick)
 
     try {
       /**

--- a/commands/RunTests.js
+++ b/commands/RunTests.js
@@ -163,11 +163,7 @@ class RunTests extends Command {
      * them to pick only those files
      */
     if (_.size(filesToPick)) {
-      testFiles = _.filter(testFiles, (file) => {
-        return !!_.find(filesToPick, (selectedFile) => {
-          return file.endsWith(selectedFile.trim())
-        })
-      })
+      testFiles = _.intersectionWith(testFiles, filesToPick, _.includes)
       debug('post --files filter %j', testFiles)
     }
 

--- a/commands/RunTests.js
+++ b/commands/RunTests.js
@@ -164,8 +164,8 @@ class RunTests extends Command {
      */
     if (_.size(filesToPick)) {
       testFiles = _.filter(testFiles, (file) => {
-        return !!_.find(filesToPick, (selectedFile) => {
-          return file.endsWith(selectedFile.trim())
+        return _.some(filesToPick, (selectedFile) => {
+          return file.includes(selectedFile.trim())
         })
       })
       debug('post --files filter %j', testFiles)

--- a/commands/RunTests.js
+++ b/commands/RunTests.js
@@ -163,7 +163,11 @@ class RunTests extends Command {
      * them to pick only those files
      */
     if (_.size(filesToPick)) {
-      testFiles = _.intersectionWith(testFiles, filesToPick, _.includes)
+      testFiles = _.filter(testFiles, (file) => {
+        return !!_.find(filesToPick, (selectedFile) => {
+          return file.endsWith(selectedFile.trim())
+        })
+      })
       debug('post --files filter %j', testFiles)
     }
 

--- a/src/Cli/index.js
+++ b/src/Cli/index.js
@@ -137,7 +137,6 @@ class Cli {
       testFiles = testFiles.filter(this._filterCallback)
     }
 
-
     /**
      * If there are specific files defined, then grep on
      * them to pick only those files

--- a/test/unit/cli.spec.js
+++ b/test/unit/cli.spec.js
@@ -165,8 +165,8 @@ test.group('Cli', (group) => {
 
     const testsFilesAll = await this.cli.getTestFiles(['sample'])
     assert.deepEqual(testsFilesAll, [
-      upath.normalize(unitTestFileTwo),
-      upath.normalize(unitTestFileOne)
+      upath.normalize(unitTestFileOne),
+      upath.normalize(unitTestFileTwo)
     ])
   })
 })

--- a/test/unit/cli.spec.js
+++ b/test/unit/cli.spec.js
@@ -152,4 +152,21 @@ test.group('Cli', (group) => {
     const testsFiles = await this.cli.getTestFiles()
     assert.deepEqual(testsFiles, [upath.normalize(functionalTestFile)])
   })
+
+  test('filter for files', async (assert) => {
+    const unitTestFileOne = path.join(this.helpers.appRoot(), 'test/unit/sample-one.spec.js')
+    const unitTestFileTwo = path.join(this.helpers.appRoot(), 'test/unit/sample-two.spec.js')
+
+    await fs.ensureFile(unitTestFileOne)
+    await fs.ensureFile(unitTestFileTwo)
+
+    const testsFiles = await this.cli.getTestFiles(['sample-one'])
+    assert.deepEqual(testsFiles, [upath.normalize(unitTestFileOne)])
+
+    const testsFilesAll = await this.cli.getTestFiles(['sample'])
+    assert.deepEqual(testsFilesAll, [
+      upath.normalize(unitTestFileTwo),
+      upath.normalize(unitTestFileOne)
+    ])
+  })
 })


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

Testing a single file currently requires you to specify the entire file name, including the file extension. E.g. 

```bash
adonis test -f 'UserService.spec.js'
```

With this fix in place, simpy `UserService` or even `User` would be enough. This then nicely aligns with the way grep works

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ x I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-vow/blob/develop/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)